### PR TITLE
Add missing `+` to plotting code

### DIFF
--- a/R/plot_icc.R
+++ b/R/plot_icc.R
@@ -637,7 +637,7 @@ plot_empirical_icc2 <- function(resp, item, bins = 10, binwidth = NULL,
 
   # Add common graph elements
   p <- p +
-    ggplot2::labs(x = x_label, y = "Proportion Correct", title = title)
+    ggplot2::labs(x = x_label, y = "Proportion Correct", title = title) +
     ggplot2::guides(x = ggplot2::guide_axis(n.dodge = n_dodge,
                                             check.overlap = TRUE)) +
     ggplot2::ylim(c(0, 1)) +


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break irt.

While I'm not sure why the error we observed is new, the cause seems to be simply a missing `+` somewhere in the plotting code, so that is what this PR aims to fix.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of February. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help irt get out a fix if necessary.